### PR TITLE
remove the requirement for command line arguments

### DIFF
--- a/newpost.py
+++ b/newpost.py
@@ -7,8 +7,13 @@ import time
 #POST_PATH = "/path/to/your/posts/location/"
 
 def main(argv):
-    postTitle = argv[1]
-    postCategory = argv[2]
+    try:
+        postTitle = argv[1]
+        postCategory = argv[2]
+    except:
+		postTitle = "DEFAULT TITLE"
+		postCategory = "DEFAULT CATEGORY"
+
     todayDate = time.strftime('%Y-%m-%d',time.localtime(time.time()))
     currentTime = time.strftime('%H:%M',time.localtime(time.time()))
     

--- a/newpost.py
+++ b/newpost.py
@@ -11,8 +11,8 @@ def main(argv):
         postTitle = argv[1]
         postCategory = argv[2]
     except:
-		postTitle = "DEFAULT TITLE"
-		postCategory = "DEFAULT CATEGORY"
+        postTitle = "DEFAULT TITLE"
+        postCategory = "DEFAULT CATEGORY"
 
     todayDate = time.strftime('%Y-%m-%d',time.localtime(time.time()))
     currentTime = time.strftime('%H:%M',time.localtime(time.time()))


### PR DESCRIPTION
For those of us who are lazy, this could be a way of specifying the categories and the title in the post file instead of having to do it when calling the python script. In any case, a user would have to be editing the post file anyways to write the post. I like the script. I was going to write the same thing until I found this one :smile: 
